### PR TITLE
Changed the http status code in response to 404 when contract address is not found

### DIFF
--- a/server.go
+++ b/server.go
@@ -40,11 +40,12 @@ func getInfoHandler(w http.ResponseWriter, r *http.Request) {
 			Message: "could not find contract address",
 		}
 		msg, _ := json.Marshal(m)
+		w.WriteHeader(http.StatusNotFound)
 		w.Write(msg)
 		return
 	}
 
-	new := BalanceResponse{
+	balanceResponse := BalanceResponse{
 		Name:       name,
 		Symbol:     token,
 		Decimals:   decimals,
@@ -54,7 +55,7 @@ func getInfoHandler(w http.ResponseWriter, r *http.Request) {
 		Block:      block,
 	}
 
-	j, err := json.Marshal(new)
+	j, err := json.Marshal(balanceResponse)
 
 	if err == nil {
 		w.Write(j)
@@ -73,6 +74,7 @@ func getTokenHandler(w http.ResponseWriter, r *http.Request) {
 	_, balance, _, _, _, _, err := GetAccount(contract, wallet)
 
 	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
 		w.Write([]byte("0.0"))
 		return
 	} else {


### PR DESCRIPTION
I'm currently trying to consume the TokenBalance API from an android app.

When I tried to run my first test I would always get an empty balanceResponse json object in the response. After a while I finally realized that the contract address that I was using in the request was missing a character (facepalm).

I would have been much helpful to get a 404 (or something different from 200 OK) in the response object since I'm using retrofit and it does the response.body deserialization automagically for me preventing me from seen the actual error message.